### PR TITLE
Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,12 @@ should be passed to the first function, and list the function names under
 	]
 }
 
-// wrap schedule in the skej() function
-skej(schedule)
+/*
+wrap schedule in the skej() function
+and include the OpenFaaS gateway URL, defaults to http://localhost:8080
+if no URL is supplied
+*/
+skej(schedule, 'http://11.11.11.11:8080')
 ```
 See the `example.js` file for the completed description.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Skej allows you to declaratively schedule events for OpenFaaS functions.
 #### How To
 
 ###### Prerequisites
+Requires NodeJS version 6.4.0 and up.
+
 Redis should be running on port 6379. This is easy to do with docker
 ```
 docker run -d -p 6379:6379 redis

--- a/example.js
+++ b/example.js
@@ -38,6 +38,7 @@ skej({
 			onFinished: x => console.log('Piped Function Wordcount:\n', x.body)
 		},
 	]
-
-});
+// gateway URL is optional and defaults to http://localhost:8080
+// if one is not supplied
+}, 'http://45.45.45.45:8080');
 

--- a/skej/index.js
+++ b/skej/index.js
@@ -4,8 +4,8 @@ const FaaS = require('openfaas');
 const Redular = require('redular');
 const BbPromise = require('bluebird');
 
-const skej = schedule => {
-	const {invoke, compose} = FaaS('http://localhost:8080');
+const skej = (url, schedule) => {
+	const {invoke, compose} = FaaS(url);
 	const {single, pipe} = schedule;
 	const options = {
 		autoconfig: true,

--- a/skej/index.js
+++ b/skej/index.js
@@ -4,7 +4,7 @@ const FaaS = require('openfaas');
 const Redular = require('redular');
 const BbPromise = require('bluebird');
 
-const skej = (url, schedule) => {
+const skej = (schedule, url = 'http://localhost:8080') => {
 	const {invoke, compose} = FaaS(url);
 	const {single, pipe} = schedule;
 	const options = {


### PR DESCRIPTION
Support custom gateway URL's i.e. `skej(schedule, url)` but defaults to localhost:8080 if URL argument is not supplied